### PR TITLE
Adding GKE Start Pod Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 * [Overview](#overview)
 * [Architecture diagram](#architecture-diagram)
 * [Getting started](#getting-started)
-	* [Clone the repository](#clone-the-repository) 
-	* [Installing the Python dependencies](#installing-the-python-dependencies) 
+	* [Clone the repository](#clone-the-repository)
+	* [Installing the Python dependencies](#installing-the-python-dependencies)
 	* [Execute the unit tests](#execute-the-unit-tests)
 	* [Build the Docker image](#build-the-docker-image)
 	* [Push the Docker image to GCP Cloud Registry](#push-the-docker-image-to-gcp-cloud-registry)
@@ -110,7 +110,7 @@ The following steps can be performed to push the local Docker image to GCP Cloud
 # configure your gcloud command with a user with permissions to push images to Cloud Registry
 gcloud auth login user@gcp-account.com
 
-# add GCP Cloud Registry as a Docker creds helper 
+# add GCP Cloud Registry as a Docker creds helper
 gcloud auth configure-docker "eu.gcr.io"
 
 # build the Docker image
@@ -138,7 +138,7 @@ With respect to this project, the JSON DAG DSL, allows a consumer to describe a 
 
 For a complete overview of the entire JSON DAG DSL specification, please see the [Swagger-UI](https://swagger.io/tools/swagger-ui/) documentation which is available within the running application at:
 
-https(s)://${HOSTNAME}:${PORT}/api/docs. 
+https(s)://${HOSTNAME}:${PORT}/api/docs.
 
 For example; http://localhost:5000/api/docs.
 
@@ -162,7 +162,29 @@ Let's start with a minimal example of defining a DAG via the JSON DAG DSL.
 
 In the above example, we define a *dag_name*, we specifiy the *mode* as `INLINE` and we define a simple *kubernetes_pod_operators* operator.
 
-In addition to the [kubernetes_pod_operator](https://cloud.google.com/composer/docs/how-to/using/using-kubernetes-pod-operator), Cloud Composer also supports a [Bash Operator](https://cloud.google.com/composer/docs/how-to/using/writing-dags#bashoperator) and a [Python Operator](https://cloud.google.com/composer/docs/how-to/using/writing-dags#pythonoperator) .
+In the below example, we define a *dag_name*, we specifiy the *mode* as `INLINE` and we define a simple *gke_start_pod_operators* operator.
+
+Let's look at a minimal GKE StartPodOperator example via the JSON DAG DSL approach.
+
+```JSON
+{
+    "dag_name" : "gke_operator1",
+    "mode": "INLINE",
+    "gke_start_pod_operators": [
+        {
+            "task_id": "gke_operator1",
+            "cluster_name": "target-cluster",
+            "name": "gke_operator1",
+            "project_id": "external-project",
+            "location": "us-central1-b",
+            "image": "us-docker.pkg.dev/cloudrun/container/hello",
+            "namespace": "default"
+        }
+    ]
+}
+```
+
+In addition to the [gke_start_pod_operators](https://airflow.apache.org/docs/apache-airflow-providers-google/stable/_api/airflow/providers/google/cloud/operators/kubernetes_engine/index.html#airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator)and[kubernetes_pod_operator](https://cloud.google.com/composer/docs/how-to/using/using-kubernetes-pod-operator), Cloud Composer also supports a [Bash Operator](https://cloud.google.com/composer/docs/how-to/using/writing-dags#bashoperator) and a [Python Operator](https://cloud.google.com/composer/docs/how-to/using/writing-dags#pythonoperator) .
 
 Let's look at a minimal Bash Operator example.
 
@@ -423,7 +445,7 @@ cd composer-api-src
 
 echo -e "${NC}"
 
-# add GCP Cloud Registry as a Docker creds helper 
+# add GCP Cloud Registry as a Docker creds helper
 echo -e "Configure Docker to push to ${BLUE}eu.gcr.io${NC}."
 gcloud auth configure-docker "eu.gcr.io"
 

--- a/composer-test/container/payloads/dag_with_execution_sequence_gke.json
+++ b/composer-test/container/payloads/dag_with_execution_sequence_gke.json
@@ -1,0 +1,52 @@
+{
+    "dag_name" : "dag6",
+    "execution_sequence": [
+        "bash_operator_06",
+        "k8s_pod_operator_example_task_06",
+        "python_operator_06",
+        "gke_start_pod_operator_example_task_06"
+    ],
+    "mode": "INLINE",
+    "kubernetes_pod_operators": [
+        {
+            "task_id": "k8s_pod_operator_example_task_06",
+            "name": "k8s_pod_example_06",
+            "image": "bash",
+            "cmds": [
+                "echo"
+            ],
+            "arguments": [
+                "'Hello from Airflow Kubernetes Pod Operator 06'"
+            ]
+        }
+    ],
+    "python_operators": [
+        {
+            "task_id": "python_operator_06",
+            "function_def": [
+                "def python_operator_func_6():",
+                "   print('Goodbye from Airflow Python Operator 06 -- DYNAMIC')"
+            ],
+            "function_name": "python_operator_func_6"
+        }
+    ],
+    "bash_operators": [
+        {
+            "task_id": "bash_operator_06",
+            "command": [
+                "echo 'Hello from Airflow Bash Operator 06';"
+            ]
+        }
+    ],
+    "gke_start_pod_operators": [
+        {
+            "task_id": "gke_operator1",
+            "cluster_name": "target-cluster",
+            "name": "gke_operator1",
+            "project_id": "external-project",
+            "location": "us-central1-b",
+            "image": "us-docker.pkg.dev/cloudrun/container/hello",
+            "namespace": "default"
+        }
+    ]
+}

--- a/composer-test/container/payloads/minimal_dag_gke_start_pod_operator.json
+++ b/composer-test/container/payloads/minimal_dag_gke_start_pod_operator.json
@@ -1,0 +1,15 @@
+{
+    "dag_name" : "gke_operator1",
+    "mode": "INLINE",
+    "gke_start_pod_operators": [
+        {
+            "task_id": "gke_operator1",
+            "cluster_name": "target-cluster",
+            "name": "gke_operator1",
+            "project_id": "external-project",
+            "location": "us-central1-b",
+            "image": "us-docker.pkg.dev/cloudrun/container/hello",
+            "namespace": "default"
+        }
+    ]
+}

--- a/composer/api/api_service.py
+++ b/composer/api/api_service.py
@@ -252,8 +252,8 @@ def git_download_file(git_url, repo_dir, file_path):
     """
     if os.environ.get('GIT_USERNAME') and os.environ.get('GIT_PASSWORD'):
         git_username = os.environ.get('GIT_USERNAME')
-        git_username = os.environ.get('GIT_PASSWORD')
-        remote = f"https://{git_username}:{git_username}@{git_url}"
+        git_password = os.environ.get('GIT_PASSWORD')
+        remote = f"https://{git_username}:{git_password}@{git_url}"
     else:
         remote = f"https://{git_url}"
     temp_dir = tempfile.gettempdir()

--- a/composer/api/api_validator.py
+++ b/composer/api/api_validator.py
@@ -93,6 +93,22 @@ def __validate_dsl_json(dsl_json):
                 raise ValueError(f"'kubernetes_pod_operator' defined but it does not contains a 'name': {operator}")
             if 'image' not in operator:
                 raise ValueError(f"'kubernetes_pod_operator' defined but it does not contains a 'image': {operator}")
+    if "gke_start_pod_operators" in dsl_json:
+        if len(dsl_json['gke_start_pod_operators']) == 0:
+            raise ValueError(f"'gke_start_pod_operators' defined but it contains no elements")
+        for operator in dsl_json['gke_start_pod_operators']:
+            if 'task_id' not in operator:
+                raise ValueError(f"'gke_start_pod_operator' defined but it does not contains a 'task_id': {operator}")
+            if 'name' not in operator:
+                raise ValueError(f"'gke_start_pod_operator' defined but it does not contains a 'name': {operator}")
+            if 'image' not in operator:
+                raise ValueError(f"'gke_start_pod_operator' defined but it does not contains a 'image': {operator}")
+            if 'cluster_name' not in operator:
+                raise ValueError(f"'gke_start_pod_operator' defined but it does not contains a 'cluster_name': {operator}")
+            if 'project_id' not in operator:
+                raise ValueError(f"'gke_start_pod_operator' defined but it does not contains a 'project_id': {operator}")
+            if 'location' not in operator:
+                raise ValueError(f"'gke_start_pod_operator' defined but it does not contains a 'location': {operator}")
     if "bash_operators" in dsl_json:
         if len(dsl_json['bash_operators']) == 0:
             raise ValueError(f"'bash_operators' defined but it contains no elements")

--- a/composer/dag/dag_template.py
+++ b/composer/dag/dag_template.py
@@ -20,6 +20,7 @@ from airflow.operators import bash_operator
 from airflow.operators import python_operator
 from airflow.contrib.kubernetes import secret
 from airflow.contrib.operators import kubernetes_pod_operator
+from airflow.providers.google.cloud.operators.kubernetes_engine import GKEStartPodOperator
 """
 NOTE: the above import statements are used dynamically within the template. Even though an IDE may indicate
 they are not used, please only remove the following imports if you are absolutely sure they are not required.

--- a/composer/dag/dag_template.py
+++ b/composer/dag/dag_template.py
@@ -394,16 +394,6 @@ else:
         payload['dynamic_functions']['start_date']
     )
 
-
-# add the schedule_interval
-if list(find_key_in_dict('schedule_interval', payload)):
-    dag.schedule_interval = get_dynamic_function(
-        'schedule_interval',
-        'schedule_interval_def',
-        'schedule_interval_name',
-        payload['dynamic_functions']['schedule_interval']
-    )
-
 # add the dag run timeout
 if list(find_key_in_dict('dagrun_timeout', payload)):
     dag.dagrun_timeout = get_dynamic_function(
@@ -415,6 +405,9 @@ if list(find_key_in_dict('dagrun_timeout', payload)):
 
 if 'dag_tags' in payload:
     dag.tags = payload['dag_tags']
+
+if 'schedule_interval' in payload:
+    dag.schedule_interval = payload['schedule_interval']
 
 if 'dag_params' in payload:
     dag.params = payload['dag_params']

--- a/composer/static/api/swagger-api.yaml
+++ b/composer/static/api/swagger-api.yaml
@@ -244,19 +244,6 @@ definitions:
         description: "Name of the function. This must match the name of the function described in start_date_def. *Optional*."
     xml:
       name: "DagStartDateFunction"
-  DagScheduledIntervalFunction:
-    type: "object"
-    properties:
-      schedule_interval_def:
-        type: "array"
-        items:
-          type: "string"
-        description: "Each element of the array contains a line of the code of the function. *Optional*."
-      schedule_interval_name:
-        type: "string"
-        description: "Name of the function. This must match the name of the function described in schedule_interval_def. *Optional*."
-    xml:
-      name: "DagScheduledIntervalFunction"
   DagRetryDelayFunction:
     type: "object"
     properties:
@@ -288,8 +275,6 @@ definitions:
     properties:
       start_date:
         $ref: "#/definitions/DagStartDateFunction"
-      schedule_interval:
-        $ref: "#/definitions/DagScheduledIntervalFunction"
       retry_delay:
         $ref: "#/definitions/DagRetryDelayFunction"
       dagrun_timeout:
@@ -656,7 +641,10 @@ definitions:
         additionalProperties:
           type: "string"
         description: "Key/value pairs to be passed to the Dag as additional parameters. *OPTIONAL*."
-      doc_md:
+      schedule_interval:
+        type: "string"
+        description: "Cron Expression with the schedule interval for this DAH, sample : `15 08 * * *` "
+      dag_doc_md:
         type: "array"
         items:
           type: "string"

--- a/composer/static/api/swagger-api.yaml
+++ b/composer/static/api/swagger-api.yaml
@@ -418,6 +418,113 @@ definitions:
                       description: "An array of node affinity expressions to match."
     xml:
       name: "KubernetesAffinity"
+  GKEStartPodOperator:
+    type: "object"
+    required:
+      - "task_id"
+      - "name"
+      - "image"
+      - "cluster_name"
+      - "project_id"
+      - "location"
+    properties:
+      cluster_name:
+        type: "string"
+        description: "Name of the cluster where to deploy the DAG. Only applies for GKEStartPodOperator"
+      project_id:
+        type: "string"
+        description: "GCP project id of the target cluster"
+      location:
+        type: "string"
+        description: "GCP location of the target cluster"
+      task_id:
+        type: "string"
+        description: "Unique name of the operator."
+      name:
+        type: "string"
+        description: "Descriptive name of the operator."
+      image:
+        type: "string"
+        description: "Name of the Docker image of the operator."
+      namespace:
+        type: "string"
+        description: "The Kubernetes namespace in which to deploy the operator."
+      cmds:
+        type: "array"
+        items:
+          type: "string"
+        description: "Array of commands to be executed by the Docker image."
+      arguments:
+        type: "array"
+        items:
+          type: "string"
+        description: "Array of arguments to be executed by the Docker image."
+      env_vars:
+        type: "object"
+        additionalProperties:
+          type: "string"
+        description: "Key/value pairs of environment variables to be passed to the operator."
+      labels:
+        type: "object"
+        additionalProperties:
+          type: "string"
+        description: "Key/value pairs of labels to be passed to the operator."
+      pod_secret_refs:
+        type: "array"
+        items:
+          type: "string"
+        description: "An array of the names of the kubernetes_secrets required by the operator."
+      image_pull_secret_refs:
+        type: "array"
+        items:
+          type: "string"
+        description: "An array of the names of the kubernetes_secrets required by the operator in order to pull the Docker image."
+      ports:
+        type: "array"
+        items:
+          type: "integer"
+          format: "int64"
+        description: "An array of the ports number to be exposed from the Docker image."
+      startup_timeout_seconds:
+        type: "integer"
+        format: "int64"
+        description: "The pod startup timeout in seconds."
+      image_pull_policy:
+        type: "string"
+        enum:
+          - "Always"
+          - "IfNotPresent"
+        description: "The Docker image pull policy; Always or IfNotPresent."
+      annotations:
+        type: "object"
+        additionalProperties:
+          type: "string"
+        description: "Key/value pairs of annotations to be passed to the operator."
+      volumes:
+        type: "array"
+        items:
+          type: "string"
+        description: "An array of the names of volumes to be used by the operator."
+      volume_mounts:
+        type: "array"
+        items:
+          type: "string"
+        description: "An array of the names of volume mounts to be used by the operator."
+      configmaps:
+        type: "array"
+        items:
+          type: "string"
+        description: "An array of the names of the config maps to be used by the operator."
+      resources:
+        type: "array"
+        items:
+          $ref: "#/definitions/KubernetesResource"
+        description: "Definition of the Kubernetes resources to be applied to the pod. *OPTIONAL*."
+      affinity:
+        $ref: "#/definitions/KubernetesAffinity"
+        description: "Node affinity rules tobe applied to the pod."
+    xml:
+      name: "GKEStartPodOperator"
   KubernetesOperator:
     type: "object"
     required:
@@ -599,5 +706,10 @@ definitions:
         items:
           $ref: "#/definitions/KubernetesOperator"
         description: "Definition of the Kubernetes operators to be executed within the Dag. *OPTIONAL*."
+      gke_start_pod_operators:
+        type: "array"
+        items:
+          $ref: "#/definitions/GKEStartPodOperator"
+        description: "Definition of the GKE Start Pod Operators to be executed within the Dag. *OPTIONAL*."
     xml:
       name: "DagDsl"

--- a/requirements.txt
+++ b/requirements.txt
@@ -223,3 +223,6 @@ zipp==3.4.0
 zope.deprecation==4.4.0
 zope.event==4.5.0
 zope.interface==5.2.0
+apache-airflow-providers-http==1.1.0
+apache-airflow-providers-google==2.0.0
+apache-airflow-backport-providers-cncf-kubernetes==2020.11.23

--- a/test.py
+++ b/test.py
@@ -1,0 +1,22 @@
+import os
+
+from airflow import models
+from airflow.providers.google.cloud.operators.kubernetes_engine import GKEStartPodOperator
+from airflow.utils.dates import days_ago
+
+with models.DAG(
+    "testgithubbruno",
+    schedule_interval=None,  # Override to match your needs
+    start_date=days_ago(1),
+    tags=['example'],
+) as dag:
+
+    pod_task = GKEStartPodOperator(
+        task_id="pod_task",
+        project_id="telefonica-digital-cloud",
+        location="europe-west2-b",
+        cluster_name="europe-west2-composer-c96de2c4-gke",
+        namespace="default",
+        image="us-docker.pkg.dev/cloudrun/container/hello",
+        name="test-pod232",
+    )


### PR DESCRIPTION
Adding GKE Start Pod Operator in order to launch pods in different clusters. The additions to the code work on the same project as the Cloud Composer environment (launch pods in a different cluster, not the Composer Cluster)
TODO : Test it in a cluster that it is in a different project, probably will need permissions for that.